### PR TITLE
remove GcCompatTrivial trait

### DIFF
--- a/libspecr/src/gc/gccompat.rs
+++ b/libspecr/src/gc/gccompat.rs
@@ -4,23 +4,12 @@ use std::convert::Infallible;
 
 /// `GcCompat` expresses that a type is compatible with the garbage collector.
 /// It is required in order to contain `GcCow` and to be the generic param to `GcCow`.
-pub trait GcCompat: GcCompatTrivial {
+pub trait GcCompat: 'static {
     /// Writes the gc'd objs, that `self` directly points to, into `buffer`.
     fn points_to(&self, buffer: &mut HashSet<usize>);
 
     /// converts self to `Any`.
     fn as_any(&self) -> &dyn Any;
-}
-
-/// a supertrait of GcCompat which can be automatically implemented for most types.
-pub trait GcCompatTrivial: 'static {
-    /// equal to `std::mem::size_of<Self>()`.
-    /// But this does not require the non-"object safe" bound `Sized`.
-    fn size(&self) -> usize;
-}
-
-impl<T: Sized + 'static> GcCompatTrivial for T {
-    fn size(&self) -> usize { std::mem::size_of::<Self>() }
 }
 
 // impls for GcCompat:

--- a/libspecr/src/gc/state.rs
+++ b/libspecr/src/gc/state.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use crate::*;
 
 // mark_and_sweep won't cleanup, if you didn't allocate at least LEEWAY_MEMORY bytes since the last cleanup.
@@ -46,7 +47,7 @@ impl GcState {
             }
         };
 
-        self.current_memory += obj.size();
+        self.current_memory += mem::size_of_val(&*obj);
         self.data[idx] = Some(obj);
 
         idx
@@ -76,7 +77,7 @@ impl GcState {
     }
 
     fn full_memory_consumption(&self) -> usize {
-        self.data.iter().map(|x| x.size()).sum::<usize>()
+        self.data.iter().map(|x| mem::size_of_val(&*x)).sum::<usize>()
     }
 
     pub fn mark_and_sweep(&mut self, root: impl GcCompat) {


### PR DESCRIPTION
@memoryleak47 I don't quite understand why this trait exists, it seems to be easy to remove. Am I missing something?