### PR TITLE
gen-minirust correct libspecr & gccompat version.

### DIFF
--- a/specr-transpile/src/main.rs
+++ b/specr-transpile/src/main.rs
@@ -64,8 +64,8 @@ fn create_cargo_toml(config: &Config) {
                 edition = \"2021\"\n\
                 \n\
                 [dependencies]\n\
-                libspecr = \"=0.1.15\"\n\
-                gccompat-derive = \"=0.1.1\"\n\
+                libspecr = \"=0.1.16\"\n\
+                gccompat-derive = \"=0.1.2\"\n\
                ", package_name);
     fs::write(config.output_path().join("Cargo.toml"), &toml).unwrap();
 }


### PR DESCRIPTION
When specr-transpile creates the gen-minirust code it defines the version of both libspecr and gccompat-derive.
This also needs to refer to 0.1.16 and 0.1.2 respectively.