### PR TITLE
Add `serde` and (de)serialization support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "bitmaps",
  "rand_core",
  "rand_xoshiro",
+ "serde",
  "sized-chunks",
  "typenum",
  "version_check",
@@ -78,6 +79,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -95,7 +102,15 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-bigint"
@@ -203,6 +218,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +245,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -362,3 +400,9 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/libspecr/Cargo.toml
+++ b/libspecr/Cargo.toml
@@ -14,6 +14,8 @@ documentation = "https://docs.rs/libspecr"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2.15"
 num-integer = "0.1.45"
-im = "15.1.0"
+im = { version = "15.1.0", features = ["serde"] }
 rand = "0.8.5"
 gccompat-derive = { path = "../gccompat-derive", version = "0.1.2" }
+serde = { version = "1.0", features = ["serde_derive"] }
+serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/libspecr/src/lib.rs
+++ b/libspecr/src/lib.rs
@@ -70,6 +70,8 @@ use gc::*;
 mod obj;
 use obj::*;
 
+mod serde;
+
 #[doc(hidden)]
 pub mod hidden {
     pub use crate::obj::*;

--- a/libspecr/src/map/func.rs
+++ b/libspecr/src/map/func.rs
@@ -65,8 +65,14 @@ impl<K: Obj, V: Obj> Map<K, V> {
 
     /// Returns the number of elements in `self`.
     pub fn len(self) -> Int {
-        Int::from(self.0.call_ref_unchecked(|m| m.len()))
+        Int::from(self.len_as_usize())
     }
+
+    /// Returns the number of elements in `self`, as `usize`.
+    pub(crate) fn len_as_usize(self) -> usize {
+        self.0.call_ref_unchecked(|m| m.len())
+    }
+
 
     /// Returns `true` if the map contains no elements.
     pub fn is_empty(self) -> bool {

--- a/libspecr/src/mutability.rs
+++ b/libspecr/src/mutability.rs
@@ -1,6 +1,7 @@
 use crate::*;
+use ::serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 /// Either `Mutable` or `Immutable`.
 #[derive(GcCompat)]
 pub enum Mutability {

--- a/libspecr/src/serde/essentials.rs
+++ b/libspecr/src/serde/essentials.rs
@@ -1,0 +1,114 @@
+use std::str::FromStr;
+
+use serde::{
+    de::{SeqAccess, Visitor},
+    ser::SerializeSeq,
+    Deserialize, Serialize,
+};
+use serde_json::Number;
+
+use crate::{gc::*, obj::Obj, Int, Map};
+
+use std::{fmt, marker::PhantomData};
+
+use im::HashMap;
+use num_bigint::BigInt;
+use serde::de::{self, Unexpected};
+
+// GcCow are an implementation detail of the Rust library; they do not show up in specr source code
+// and similarly should not show up in the JSON.
+// We thus treat them transparently when (de)serializing.
+impl<T: Serialize + GcCompat> Serialize for GcCow<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        GcCow::call_ref_unchecked(*self, |x| x.serialize(serializer))
+    }
+}
+impl<'de, T: Deserialize<'de> + GcCompat> Deserialize<'de> for GcCow<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let x = T::deserialize(deserializer)?;
+        Ok(GcCow::new(x))
+    }
+}
+
+// We want our BigInts to show up as integers in the JSON.
+// For this, we use the `"arbitrary_precision"` feature of `serde_json`, and this requires using
+// `serde_json::Number`, which has some internal magic to store arbitrary-precision integers and
+// convert them from/to JSON numbers properly.
+impl Serialize for Int {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let jv = Number::from_str(&format!("{self}")).unwrap();
+        jv.serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for Int {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let jv = Number::deserialize(deserializer)?;
+        Ok(Int::wrap(jv.as_str().parse::<BigInt>().map_err(|_| {
+            de::Error::invalid_value(
+                Unexpected::Other(format!("non-integer number {}", jv.as_str()).leak()),
+                &"an integer",
+            )
+        })?))
+    }
+}
+
+// We use this somewhat botched serialization scheme for maps so that we never generate arbitrary keys.
+// Having non-string keys does not work in (serde-)JSON and JSON is the whole point of this.
+impl<K: Serialize + Obj, V: Serialize + Obj> Serialize for Map<K, V> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut eleser = serializer.serialize_seq(Some(self.len_as_usize()))?;
+        for kv in self.iter() {
+            // This makes each element show up as JSON list with two entries, i.e. a pair.
+            eleser.serialize_element(&kv)?;
+        }
+        eleser.end()
+    }
+}
+impl<'de, K: Obj + Deserialize<'de>, V: Obj + Deserialize<'de>> Deserialize<'de> for Map<K, V> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ElmVisitor<K, V>(PhantomData<K>, PhantomData<V>);
+
+        impl<'de, K: Obj + Deserialize<'de>, V: Obj + Deserialize<'de>> Visitor<'de> for ElmVisitor<K, V> {
+            type Value = Map<K, V>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a libspecr::Map<_, _>")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut map = HashMap::new();
+
+                while let Some((k, v)) = seq.next_element::<(K, V)>()? {
+                    let None = map.insert(k, v) else {
+                        return Err(de::Error::duplicate_field(format!("{:?}", k).leak()));
+                    };
+                }
+
+                Ok(Map(GcCow::new(map)))
+            }
+        }
+
+        deserializer.deserialize_seq(ElmVisitor::<K, V>(PhantomData, PhantomData))
+    }
+}

--- a/libspecr/src/serde/mod.rs
+++ b/libspecr/src/serde/mod.rs
@@ -1,0 +1,5 @@
+// Serde implementations for newtypes that mostly just forward.
+pub mod newtypes;
+// Serde implementations that do something more complicated, for
+// "essential" types.
+pub mod essentials;

--- a/libspecr/src/serde/newtypes.rs
+++ b/libspecr/src/serde/newtypes.rs
@@ -1,0 +1,113 @@
+use serde::{de, Deserialize, Serialize};
+
+use crate::{gc::*, obj::Obj, Align, Int, List, Set, Size};
+
+// Align is serialized as a number
+impl Serialize for Align {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.bytes().serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for Align {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Align::from_bytes(Int::deserialize(deserializer)?)
+            .ok_or_else(|| de::Error::custom("invalid Align"))
+    }
+}
+
+// Size is serialized as a number
+impl Serialize for Size {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.bytes().serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for Size {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Size::from_bytes(Int::deserialize(deserializer)?)
+            .ok_or_else(|| de::Error::custom("invalid Size"))
+    }
+}
+
+// Our newtype around string is serialized as a regular String.
+impl Serialize for crate::String {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for crate::String {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(crate::String(GcCow::deserialize(deserializer)?))
+    }
+}
+
+// Names are serialized as the integers that they are, again skipping the newtype wrapper.
+impl Serialize for crate::Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for crate::Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self(Deserialize::deserialize(deserializer)?))
+    }
+}
+
+// Lists also skip the newtype wrapper.
+impl<T: Serialize + Obj> Serialize for List<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+impl<'de, T: Obj + Deserialize<'de>> Deserialize<'de> for List<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(List(GcCow::deserialize(deserializer)?))
+    }
+}
+
+// Sets also skip the newtype wrapper.
+impl<T: Serialize + Obj> Serialize for Set<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+impl<'de, T: Obj + Deserialize<'de>> Deserialize<'de> for Set<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Set(GcCow::deserialize(deserializer)?))
+    }
+}

--- a/libspecr/src/signedness.rs
+++ b/libspecr/src/signedness.rs
@@ -1,6 +1,7 @@
 use crate::*;
+use ::serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, GcCompat)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, GcCompat, Serialize, Deserialize)]
 /// Expresses whether an integer has a sign or not
 pub enum Signedness {
     #[allow(missing_docs)]

--- a/specr-transpile/src/auto_derive.rs
+++ b/specr-transpile/src/auto_derive.rs
@@ -6,7 +6,15 @@ use crate::prelude::*;
 static GENERAL_TRAITS: &[&str] = &["GcCompat", "Debug"];
 
 /// Traits only "objects" should derive. They get used in maps, sets, etc.
-static OBJ_TRAITS: &[&str] = &["Clone", "Copy", "PartialEq", "Eq", "Hash"];
+static OBJ_TRAITS: &[&str] = &[
+    "Clone",
+    "Copy",
+    "PartialEq",
+    "Eq",
+    "Hash",
+    "serde::Serialize",
+    "serde::Deserialize",
+];
 
 /// Adds `#[derive(_)]` for all missing traits in `GENERAL_TRAITS` and `OBJ_TRAITS`.
 pub fn auto_derive(mut ast: syn::File) -> syn::File {
@@ -75,11 +83,23 @@ fn add_derive_attr(t: &str, attrs: &mut Vec<Attribute>) {
 
 /// generates `#[derive(t)]`
 fn derive_attr(t: &str) -> Attribute {
-    let id = format_ident!("{}", t);
+    let mut path = Path {
+        leading_colon: None,
+        segments: Punctuated::new(),
+    };
+
+    for n in t.split("::") {
+        path.segments.push(PathSegment {
+            ident: format_ident!("{n}"),
+            arguments: PathArguments::None,
+        });
+    }
 
     // Attributes can not be parsed in of itself,
     // but only as prefix to some Item.
-    let code = quote! { #[derive(#id)] struct X; };
-    let Item::Struct(item) = parse2(code).unwrap() else { unreachable!() };
+    let code = quote! { #[derive(#path)] struct X; };
+    let Item::Struct(item) = parse2(code).unwrap() else {
+        unreachable!()
+    };
     item.attrs[0].clone()
 }

--- a/specr-transpile/src/auto_obj_bound.rs
+++ b/specr-transpile/src/auto_obj_bound.rs
@@ -5,39 +5,42 @@ pub fn auto_obj_bound(mut ast: syn::File) -> syn::File {
     for i in ast.items.iter_mut() {
         match i {
             Item::Struct(s) => {
-                add_bound(&mut s.generics);
+                add_obj_bound(&mut s.generics);
             },
             Item::Enum(e) => {
-                add_bound(&mut e.generics);
+                add_obj_bound(&mut e.generics);
             },
             Item::Fn(f) => {
-                add_bound(&mut f.sig.generics);
+                add_obj_bound(&mut f.sig.generics);
             },
             Item::Trait(t) => {
-                add_bound(&mut t.generics);
-                add_bound_punct(&mut t.supertraits);
+                add_obj_bound(&mut t.generics);
+                add_obj_bound_punct(&mut t.supertraits);
                 for it in &mut t.items {
                     match it {
                         TraitItem::Fn(itm) => {
-                            add_bound(&mut itm.sig.generics);
+                            add_obj_bound(&mut itm.sig.generics);
                         },
                         TraitItem::Type(itt) => {
-                            add_bound(&mut itt.generics);
-                            add_bound_punct(&mut itt.bounds);
+                            add_obj_bound(&mut itt.generics);
+                            add_obj_bound_punct(&mut itt.bounds);
+                            add_serde_bounds_punct(&mut itt.bounds);
                         },
                         _ => {},
                     }
                 }
             },
             Item::Impl(i) => {
-                add_bound(&mut i.generics);
+                add_obj_bound(&mut i.generics);
+                // We need serde bounds for trait impls. We choose to add them for all impl blocks for consistency.
+                add_serde_bounds(&mut i.generics);
                 for ii in &mut i.items {
                     match ii {
                         ImplItem::Fn(iim) => {
-                            add_bound(&mut iim.sig.generics);
+                            add_obj_bound(&mut iim.sig.generics);
                         },
                         ImplItem::Type(iit) => {
-                            add_bound(&mut iit.generics);
+                            add_obj_bound(&mut iit.generics);
                         },
                         _ => {},
                     }
@@ -50,15 +53,42 @@ pub fn auto_obj_bound(mut ast: syn::File) -> syn::File {
     ast
 }
 
-pub fn add_bound(g: &mut Generics) {
+pub fn add_obj_bound(g: &mut Generics) {
     for param in &mut g.params {
         let GenericParam::Type(t) = param else { continue };
-        add_bound_punct(&mut t.bounds);
+        add_obj_bound_punct(&mut t.bounds);
     }
 }
 
-pub fn add_bound_punct<T: Default>(punct: &mut Punctuated<TypeParamBound, T>) {
+pub fn add_obj_bound_punct<T: Default>(punct: &mut Punctuated<TypeParamBound, T>) {
     let b = quote! { libspecr::hidden::Obj };
+    let b: TraitBound = parse2(b).unwrap();
+    let b: TypeParamBound = b.into();
+    punct.push(b);
+}
+
+
+/// Associated types get an additional bound of `Serialize + for<'de> Deserialize<'de>`.
+/// This is because we don't include this bound in `Obj` as that messes up `serde_derive`,
+/// which then results in an "multiple `impl`s or `where` clauses satisfying `K: Deserialize<'_>` found" warning.
+/// (We could add `Serialize` to `Obj` but choose not to, for symmetry reasons.)
+/// It turns out that this is not just necessary in associated types, but also in `impl<T1, .., Tn> Trait for Type` generic 
+/// parameters (T1 to Tn), since these usually end up contributing to the associated type.
+pub fn add_serde_bounds(g: &mut Generics) {
+    for param in &mut g.params {
+        let GenericParam::Type(t) = param else {
+            continue;
+        };
+        add_serde_bounds_punct(&mut t.bounds);
+    }
+}
+
+pub fn add_serde_bounds_punct<T: Default>(punct: &mut Punctuated<TypeParamBound, T>) {
+    let b = quote! { for<'de> serde::Deserialize<'de> };
+    let b: TraitBound = parse2(b).unwrap();
+    let b: TypeParamBound = b.into();
+    punct.push(b);
+    let b = quote! { serde::Serialize };
     let b: TraitBound = parse2(b).unwrap();
     let b: TypeParamBound = b.into();
     punct.push(b);

--- a/specr-transpile/src/main.rs
+++ b/specr-transpile/src/main.rs
@@ -73,6 +73,7 @@ fn create_cargo_toml(config: &Config) {
                 \n\
                 [dependencies]\n\
                 libspecr = {libspecr}\n\
+                serde = {{version = \"1.0\", features = [\"derive\"]}}\n\
                ", name = package_name);
     fs::write(config.output_path().join("Cargo.toml"), &toml).unwrap();
 }


### PR DESCRIPTION
This PR is preparatory work to allow (de)serializing Minirust programs. That requires making the `libspecr` compatible with serde, and also changing the transpiler to automatically implement `Serialize` and `Deserialize`.

The changes for `Serialize` are straightforward. Also supporting `Deserialize` is somewhat more involved since that trait has a lifetime, and this makes trait resolution think that there are two sources for the `Deserialize` trait, since we bound everything with `for<'de> Deserialize<'de>` as our types don't care about lifetimes. Either way, the solution is to not add automatic `for<'a> Deserialize<'a>` bounds to *everything* but only in some choice places, namely on generic associated types and in trait implementation generic parameters. This is enough to make specr compile. (Ideally we would roll our own `derive(Deserialize)` which generates `for<'de>` bounds but that seemed too complicated). See `auto_obj_bound.rs` which is now a bit more wonky.

Either way, this is enough to bump the version. Maybe it is even enough to bump the major version, since we add new bounds unconditionally and that theoretically could probably have broken some "other" specr code out there that is not minirust.