### PR TITLE
add Ord and PartialOrd implementations

### DIFF
--- a/libspecr/src/endianness.rs
+++ b/libspecr/src/endianness.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
 /// Either `LittleEndian` or `BigEndian`.
 pub enum Endianness {
     #[allow(missing_docs)]

--- a/libspecr/src/gc/trait_passthrough.rs
+++ b/libspecr/src/gc/trait_passthrough.rs
@@ -28,3 +28,16 @@ impl<T> Default for GcCow<T> where T: Default + GcCompat {
         Self::new(T::default())
     }
 }
+
+
+impl<T> PartialOrd for GcCow<T> where T: GcCompat + PartialOrd + Clone {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.call_ref1_unchecked(*other, |x, y| x.partial_cmp(y))
+    }
+}
+
+impl<T> Ord for GcCow<T> where T: GcCompat + Ord + Clone {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.call_ref1_unchecked(*other, |x, y| x.cmp(y))
+    }
+}

--- a/libspecr/src/list/mod.rs
+++ b/libspecr/src/list/mod.rs
@@ -7,7 +7,7 @@ use crate::*;
 mod iter;
 mod func;
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, GcCompat)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, GcCompat, PartialOrd, Ord)]
 /// Garbage-collected `Vec`-like datastructure implementing `Copy`.
 /// Note that functions which seem to mutate the `List`, actually clone the list and allocate a new `GcCow` under the hood.
 pub struct List<T: Obj>(pub(crate) GcCow<IMVector<T>>);

--- a/libspecr/src/map/mod.rs
+++ b/libspecr/src/map/mod.rs
@@ -7,8 +7,10 @@ use crate::*;
 mod func;
 mod iter;
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, GcCompat)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, GcCompat, PartialOrd, Ord)]
 /// Garbage-collected hash map implementing `Copy`.
+/// This implements `Ord` but the order is not meaningful; this is just so one can use `BTreeMap`s.
+/// In particular, the order might differ across two runs of the same program.
 pub struct Map<K: Obj, V: Obj>(pub(crate) GcCow<IMHashMap<K, V>>);
 
 impl<K: Obj, V: Obj> GcCompat for IMHashMap<K, V> {

--- a/libspecr/src/mutability.rs
+++ b/libspecr/src/mutability.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use ::serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 /// Either `Mutable` or `Immutable`.
 #[derive(GcCompat)]
 pub enum Mutability {

--- a/libspecr/src/obj.rs
+++ b/libspecr/src/obj.rs
@@ -8,5 +8,5 @@ use crate::*;
 /// will implement this trait.
 ///
 /// A notable exception is closures.
-pub trait Obj: GcCompat + Copy + Debug + Eq + Hash {}
-impl<T> Obj for T where T: GcCompat + Copy + Debug + Eq + Hash {}
+pub trait Obj: GcCompat + Copy + Debug + Eq + Hash + Ord {}
+impl<T> Obj for T where T: GcCompat + Copy + Debug + Eq + Hash + Ord {}

--- a/libspecr/src/set/mod.rs
+++ b/libspecr/src/set/mod.rs
@@ -7,8 +7,10 @@ use crate::*;
 mod func;
 mod iter;
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, GcCompat)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, GcCompat, PartialOrd, Ord)]
 /// Garbage-collected hash set implementing `Copy`.
+/// This implements `Ord` but the order is not meaningful; this is just so one can use `BTreeMap`s.
+/// In particular, the order might differ across two runs of the same program.
 pub struct Set<T: Obj>(pub(crate) GcCow<IMHashSet<T>>);
 
 impl<T: Obj> GcCompat for IMHashSet<T> {

--- a/libspecr/src/signedness.rs
+++ b/libspecr/src/signedness.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use ::serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, GcCompat, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, GcCompat, Serialize, Deserialize, PartialOrd, Ord)]
 /// Expresses whether an integer has a sign or not
 pub enum Signedness {
     #[allow(missing_docs)]

--- a/libspecr/src/string.rs
+++ b/libspecr/src/string.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 use std::fmt::{Display, Formatter, Error};
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, GcCompat)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, GcCompat, PartialOrd, Ord)]
 /// Garbage-collected wrapper around `std::string::String` implementing `Copy`.
 pub struct String(pub(crate) GcCow<std::string::String>);
 

--- a/specr-transpile/src/auto_derive.rs
+++ b/specr-transpile/src/auto_derive.rs
@@ -12,6 +12,9 @@ static OBJ_TRAITS: &[&str] = &[
     "PartialEq",
     "Eq",
     "Hash",
+    // The order isn't meaningful but useful for using BTree types.
+    "PartialOrd",
+    "Ord",
     "serde::Serialize",
     "serde::Deserialize",
 ];


### PR DESCRIPTION
As requested by @nikomatsakis in [#t-types/formality > MiniRust errors](https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality/topic/MiniRust.20errors/with/592799809).

This should work without any changes to minirust itself. At least it does so on my machine (I tested it FRFR this time :wink: )