### PR TITLE
Update to latest changes in the handling of the try features

### DIFF
--- a/libspecr/src/ndresult.rs
+++ b/libspecr/src/ndresult.rs
@@ -1,7 +1,7 @@
 use std::ops::{Try, FromResidual, ControlFlow, Residual, Yeet};
 use std::convert::Infallible;
 
-use crate::MyInfallible;
+use crate::unnameable_infallible::MyInfallible;
 
 /// Conceptually, this is a `Nondet<Result<T, E>>`.
 ///

--- a/libspecr/src/ndresult.rs
+++ b/libspecr/src/ndresult.rs
@@ -1,6 +1,8 @@
 use std::ops::{Try, FromResidual, ControlFlow, Residual, Yeet};
 use std::convert::Infallible;
 
+use crate::MyInfallible;
+
 /// Conceptually, this is a `Nondet<Result<T, E>>`.
 ///
 /// This newtype is necessary so that applying `?` on a `NdResult<T, E>` yields `T` and not `Result<T, E>`.
@@ -59,8 +61,8 @@ impl<T, E> FromResidual<Result<Infallible, E>> for NdResult<T, E> {
 }
 
 // in order to use `?` on Nondet in a NdResult-returning fn.
-impl<T, E> FromResidual<Infallible> for NdResult<T, E> {
-    fn from_residual(residual: Infallible) -> Self {
+impl<T, E> FromResidual<MyInfallible> for NdResult<T, E> {
+    fn from_residual(residual: MyInfallible) -> Self {
         match residual {}
     }
 }

--- a/libspecr/src/ndresult.rs
+++ b/libspecr/src/ndresult.rs
@@ -1,7 +1,7 @@
 use std::ops::{Try, FromResidual, ControlFlow, Residual, Yeet};
 use std::convert::Infallible;
 
-use crate::MyInfallible;
+use crate::NondetResidual;
 
 /// Conceptually, this is a `Nondet<Result<T, E>>`.
 ///
@@ -61,8 +61,8 @@ impl<T, E> FromResidual<Result<Infallible, E>> for NdResult<T, E> {
 }
 
 // in order to use `?` on Nondet in a NdResult-returning fn.
-impl<T, E> FromResidual<MyInfallible> for NdResult<T, E> {
-    fn from_residual(residual: MyInfallible) -> Self {
+impl<T, E> FromResidual<NondetResidual> for NdResult<T, E> {
+    fn from_residual(residual: NondetResidual) -> Self {
         match residual {}
     }
 }

--- a/libspecr/src/ndresult.rs
+++ b/libspecr/src/ndresult.rs
@@ -1,7 +1,7 @@
 use std::ops::{Try, FromResidual, ControlFlow, Residual, Yeet};
 use std::convert::Infallible;
 
-use crate::unnameable_infallible::MyInfallible;
+use crate::MyInfallible;
 
 /// Conceptually, this is a `Nondet<Result<T, E>>`.
 ///

--- a/libspecr/src/nondet.rs
+++ b/libspecr/src/nondet.rs
@@ -19,9 +19,17 @@ pub fn pick<T: Obj>(distr: impl Distribution<T>, f: impl Fn(T) -> bool) -> crate
     panic!("Timeout! `pick` could not find a valid value.");
 }
 
-/// An empty type that we can implement foreign traits on without violating trait solver rules.
-/// Used because `Try` requires that its `Residual` implements a certain trait.
-pub enum MyInfallible {}
+pub(crate) mod unnameable_infallible {
+
+    /// An empty type that we can implement foreign traits on without violating coherence rules.
+    /// Used because `Try` requires that its `Residual` implements a certain trait.
+    /// This type is not `pub`-licly nameable directly due to the surrounding module,
+    /// but still `pub` since it can be referred to as `Nondet<T>::Residual` due to the trait implementation below.
+    pub enum MyInfallible {}
+
+}
+
+use unnameable_infallible::MyInfallible;
 
 /// The `predict` function from the minirust spec. See [Non-determinism](https://github.com/minirust/minirust/blob/master/README.md#non-determinism).
 pub fn predict<T>(_f: impl Fn(T) -> bool) -> crate::Nondet<T> { unimplemented!() }

--- a/libspecr/src/nondet.rs
+++ b/libspecr/src/nondet.rs
@@ -19,7 +19,7 @@ pub fn pick<T: Obj>(distr: impl Distribution<T>, f: impl Fn(T) -> bool) -> crate
     panic!("Timeout! `pick` could not find a valid value.");
 }
 
-pub(crate) mod unnameable_infallible {
+pub(crate) mod sealed {
 
     /// An empty type that we can implement foreign traits on without violating coherence rules.
     /// Used because `Try` requires that its `Residual` implements a certain trait.
@@ -29,7 +29,7 @@ pub(crate) mod unnameable_infallible {
 
 }
 
-use unnameable_infallible::MyInfallible;
+pub(crate) use sealed::MyInfallible;
 
 /// The `predict` function from the minirust spec. See [Non-determinism](https://github.com/minirust/minirust/blob/master/README.md#non-determinism).
 pub fn predict<T>(_f: impl Fn(T) -> bool) -> crate::Nondet<T> { unimplemented!() }

--- a/libspecr/src/nondet.rs
+++ b/libspecr/src/nondet.rs
@@ -19,24 +19,20 @@ pub fn pick<T: Obj>(distr: impl Distribution<T>, f: impl Fn(T) -> bool) -> crate
     panic!("Timeout! `pick` could not find a valid value.");
 }
 
-pub(crate) mod sealed {
 
-    /// An empty type that we can implement foreign traits on without violating coherence rules.
-    /// Used because `Try` requires that its `Residual` implements a certain trait.
-    /// This type is not `pub`-licly nameable directly due to the surrounding module,
-    /// but still `pub` since it can be referred to as `Nondet<T>::Residual` due to the trait implementation below.
-    pub enum MyInfallible {}
+/// The `Try::Residual` for `Nondet`. This type is empty because `Nondet` has no residual
+/// as using the `?` operator on a `Nondet<T>` can not fail. We can not use `Infallible` here
+/// since we must implement the `Residual` trait, which coherence blocks us from doing for
+/// foreign types.
+pub enum NondetResidual {}
 
-}
-
-pub(crate) use sealed::MyInfallible;
 
 /// The `predict` function from the minirust spec. See [Non-determinism](https://github.com/minirust/minirust/blob/master/README.md#non-determinism).
 pub fn predict<T>(_f: impl Fn(T) -> bool) -> crate::Nondet<T> { unimplemented!() }
 
 impl<T> Try for Nondet<T> {
     type Output = T;
-    type Residual = MyInfallible;
+    type Residual = NondetResidual;
 
     fn from_output(output: Self::Output) -> Self {
         Nondet(output)
@@ -47,12 +43,12 @@ impl<T> Try for Nondet<T> {
     }
 }
 
-impl<T> FromResidual<MyInfallible> for Nondet<T> {
-    fn from_residual(residual: MyInfallible) -> Self {
+impl<T> FromResidual<NondetResidual> for Nondet<T> {
+    fn from_residual(residual: NondetResidual) -> Self {
         match residual {}
     }
 }
 
-impl<T> Residual<T> for MyInfallible {
+impl<T> Residual<T> for NondetResidual {
     type TryType = Nondet<T>;
 }

--- a/libspecr/src/nondet.rs
+++ b/libspecr/src/nondet.rs
@@ -1,6 +1,5 @@
 use crate::*;
 
-use std::convert::Infallible;
 use std::ops::*;
 
 #[derive(Copy, Clone, GcCompat)]
@@ -20,12 +19,16 @@ pub fn pick<T: Obj>(distr: impl Distribution<T>, f: impl Fn(T) -> bool) -> crate
     panic!("Timeout! `pick` could not find a valid value.");
 }
 
+/// An empty type that we can implement foreign traits on without violating trait solver rules.
+/// Used because `Try` requires that its `Residual` implements a certain trait.
+pub enum MyInfallible {}
+
 /// The `predict` function from the minirust spec. See [Non-determinism](https://github.com/minirust/minirust/blob/master/README.md#non-determinism).
 pub fn predict<T>(_f: impl Fn(T) -> bool) -> crate::Nondet<T> { unimplemented!() }
 
 impl<T> Try for Nondet<T> {
     type Output = T;
-    type Residual = Infallible;
+    type Residual = MyInfallible;
 
     fn from_output(output: Self::Output) -> Self {
         Nondet(output)
@@ -36,8 +39,12 @@ impl<T> Try for Nondet<T> {
     }
 }
 
-impl<T> FromResidual<Infallible> for Nondet<T> {
-    fn from_residual(residual: Infallible) -> Self {
+impl<T> FromResidual<MyInfallible> for Nondet<T> {
+    fn from_residual(residual: MyInfallible) -> Self {
         match residual {}
     }
+}
+
+impl<T> Residual<T> for MyInfallible {
+    type TryType = Nondet<T>;
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-04-01"
+channel = "nightly-2026-05-01"


### PR DESCRIPTION
I don't know what specifically changed in `rustc` but it started breaking on `nightly-2026-04-17`. Ever since then we get this error:
```
error[E0277]: the trait bound `Infallible: std::ops::Residual<T>` is not satisfied
    --> /home/johannes/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libspecr-0.1.40/src/nondet.rs:28:21
     |
  28 |     type Residual = Infallible;
     |                     ^^^^^^^^^^ the nightly-only, unstable trait `std::ops::Residual<T>` is not implemented for `Infallible`
```

As a result, we need to implement `Residual<T>` for `Infallible`. This is impossible due to orphan rules, so we need our own infallible. To keep compatibility between `Nondet` and `NdResult`, we also need to tweak an impl for the latter.